### PR TITLE
Names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,4 +2,4 @@
 # It is not intended for manual editing.
 [[package]]
 name = "ezcli"
-version = "0.1.0"
+version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ezcli"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Alexander Johnston <Aliics@hotmail.com>"]
 edition = "2018"
 repository = "https://github.com/Aliics/ezcli"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ on whether or not a CLI option is passed in with the same name.
 ```rust
 use ezcli::flag;
 
-flag!(my_boolean); // my_boolean is true if program args contain --my_boolean
+// my_boolean is true if program args contain "--my_boolean"
+flag!(my_boolean); 
 ```
 
 # option
@@ -20,5 +21,17 @@ when not, it'll be `None`.
 ```rust
 use ezcli::option;
 
-option!(my_arg); // my_arg is Some(x) if given --my_arg x, otherwise None 
+// my_arg is Some(x) if given "--my_arg x", otherwise None 
+option!(my_arg);
+```
+
+# named_flag
+Command line argument for on/off state. Using the `named_flag` macro you pass a 
+variable name in and it is now available to that scope. The variables value 
+is determined on whether or not a CLI option is passed in with a given name.
+```rust
+use ezcli::{named_flag, name::Name};
+
+// my_boolean is available to the program but accepts "-b" or "--my-boolean" 
+named_flag!(my_boolean, Name::new("my-boolean", "b"));
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod name;
+
 /// Command line argument flag for on/off state.
 ///
 /// Uses `std::env:args()` to determine the arguments

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,22 +2,26 @@ pub mod name;
 
 /// Command line argument flag for on/off state.
 ///
-/// Uses `std::env:args()` to determine the arguments
-/// passed to the program. If there is an argument matching
-/// the flag's name then this variable will be truthy.
+/// Uses `std::env:args()` to determine the arguments passed to the program.
+/// If there is an argument matching the flag's name then this variable will be
+/// truthy.
 /// ```
 /// use ezcli::flag;
 ///
 /// flag!(my_boolean);
 /// ```
-/// In some case of not wanting to use the program's environment
-/// arguments using a slice is also possible.
+/// In some case of not wanting to use the program's environment arguments
+/// using a slice is also possible.
 /// ```
 /// use ezcli::flag;
 ///
 /// let args = ["--my_boolean"];
 /// flag!(my_boolean, args);
 /// ```
+/// If the command line argument name should be different to the variable name
+/// then use [`named_flag`].
+///
+/// [`named_flag`]: ./macro.named_flag.html
 #[macro_export]
 macro_rules! flag {
     ($name:tt, $args:ident) => {
@@ -36,16 +40,16 @@ macro_rules! flag {
 
 /// Optional command line argument with associated value.
 ///
-/// When provided via command line it will return `Some` wrapping
-/// the value passed along with it. `None` will be returned when
-/// the option is not provided or does not follow syntax.
+/// When provided via command line it will return `Some` wrapping the value
+/// passed along with it. `None` will be returned when the option is not
+/// provided or does not follow syntax.
 /// ```
 /// use ezcli::option;
 ///
 /// option!(my_option);
 /// ```
-/// In some case of not wanting to use the program's environment
-/// arguments using a slice is also possible.
+/// In some case of not wanting to use the program's environment arguments
+/// using a slice is also possible.
 /// ```
 /// use ezcli::option;
 ///

--- a/src/name.rs
+++ b/src/name.rs
@@ -1,0 +1,49 @@
+pub struct Name {
+    pub long: Option<String>,
+    pub short: Option<String>,
+}
+
+pub struct NameBuilder(Name);
+
+impl NameBuilder {
+    pub fn new() -> Self {
+        Self(Name {
+            long: None,
+            short: None,
+        })
+    }
+
+    pub fn long(mut self, name: &str) -> Self {
+        self.0.long = Some(name.to_string());
+        self
+    }
+
+    pub fn short(mut self, name: &str) -> Self {
+        self.0.short = Some(name.to_string());
+        self
+    }
+
+    pub fn build(self) -> Name {
+        self.0
+    }
+}
+
+#[macro_export]
+macro_rules! named_flag {
+    ($name:tt, $named:expr, $args:ident) => {
+        let $name = $args
+            .iter()
+            .find(|s| {
+                if $named.long.is_some() {
+                    return **s == format!("--{}", $named.long.unwrap());
+                }
+
+                if $named.short.is_some() {
+                    return **s == format!("-{}", $named.short.unwrap());
+                }
+
+                false
+            })
+            .is_some();
+    };
+}

--- a/src/name.rs
+++ b/src/name.rs
@@ -3,32 +3,26 @@ pub struct Name {
     pub short: Option<String>,
 }
 
-pub struct NameBuilder(Name);
+impl Name {
+    pub fn new(long: &str, short: &str) -> Self {
+        Self {
+            long: Some(long.to_string()),
+            short: Some(short.to_string()),
+        }
+    }
 
-impl NameBuilder {
-    pub fn new() -> Self {
-        Self(Name {
-            long: None,
+    pub fn long(name: &str) -> Self {
+        Self {
+            long: Some(name.to_string()),
             short: None,
-        })
+        }
     }
 
-    pub fn of_long_and_short(long: &str, short: &str) -> Self {
-        NameBuilder::new().long(long).short(short)
-    }
-
-    pub fn long(mut self, name: &str) -> Self {
-        self.0.long = Some(name.to_string());
-        self
-    }
-
-    pub fn short(mut self, name: &str) -> Self {
-        self.0.short = Some(name.to_string());
-        self
-    }
-
-    pub fn build(self) -> Name {
-        self.0
+    pub fn short(name: &str) -> Self {
+        Self {
+            long: None,
+            short: Some(name.to_string()),
+        }
     }
 }
 

--- a/src/name.rs
+++ b/src/name.rs
@@ -1,9 +1,20 @@
+/// Struct represents a long and/or short name from the command line.
+///
+/// Both long and short are option string for what to be accepted, but
+/// one of them must be provided to yield results. If the variable name
+/// is to be used instead, then refer to [`flag`] or [`option`].
+///
+/// [`flag`]: ./macro.flag.html
+/// [`option`]: ./macro.option.html
 pub struct Name {
     pub long: Option<String>,
     pub short: Option<String>,
 }
 
 impl Name {
+    /// Create a [`Name`] with a long and a short name as the parameters.
+    ///
+    /// [`Name`]: ./struct.Name.html
     pub fn new(long: &str, short: &str) -> Self {
         Self {
             long: Some(long.to_string()),
@@ -11,6 +22,9 @@ impl Name {
         }
     }
 
+    /// Create a [`Name`] with just a long name.
+    ///
+    /// [`Name`]: ./struct.Name.html
     pub fn long(name: &str) -> Self {
         Self {
             long: Some(name.to_string()),
@@ -18,6 +32,9 @@ impl Name {
         }
     }
 
+    /// Create a [`Name`] with just a short name.
+    ///
+    /// [`Name`]: ./struct.Name.html
     pub fn short(name: &str) -> Self {
         Self {
             long: None,
@@ -26,6 +43,31 @@ impl Name {
     }
 }
 
+/// Command line argument macro for named flags.
+///
+/// The [`flag`] macro does not allow for an alias over the variable name
+/// already given. This macro allows you to pass a [`Name`] in as a parameter
+/// to create flags with a long and short name variant.
+/// ```
+/// use ezcli::{named_flag, name::Name};
+///
+/// // Macro creates variable called my_flag.
+/// // Accepts --cool-flag to be passed via CLI.
+/// named_flag!(my_flag, Name::long("cool-flag"));
+/// ```
+/// Also allows for a slice of args to be passed in.
+/// ```
+/// use ezcli::{named_flag, name::Name};
+///
+/// let mut args = ["f"];
+///
+/// // Macros creates variable called flag.
+/// // Accepts -f as a short argument.
+/// named_flag!(flag, Name::short("f"));
+/// ```
+///
+/// [`flag`]: ./macro.flag.html
+/// [`Name`]: ./name/struct.Name.html
 #[macro_export]
 macro_rules! named_flag {
     ($name:tt, $named:expr, $args:ident) => {

--- a/src/name.rs
+++ b/src/name.rs
@@ -13,6 +13,10 @@ impl NameBuilder {
         })
     }
 
+    pub fn of_long_and_short(long: &str, short: &str) -> Self {
+        NameBuilder::new().long(long).short(short)
+    }
+
     pub fn long(mut self, name: &str) -> Self {
         self.0.long = Some(name.to_string());
         self

--- a/src/name.rs
+++ b/src/name.rs
@@ -29,19 +29,29 @@ impl Name {
 #[macro_export]
 macro_rules! named_flag {
     ($name:tt, $named:expr, $args:ident) => {
-        let $name = $args
-            .iter()
-            .find(|s| {
-                if $named.long.is_some() {
-                    return **s == format!("--{}", $named.long.unwrap());
-                }
-
-                if $named.short.is_some() {
-                    return **s == format!("-{}", $named.short.unwrap());
-                }
-
-                false
-            })
-            .is_some();
+        let $name = $crate::name::_named_flag($named, &mut $args);
     };
+    ($name:tt, $named:expr) => {
+        let $name = {
+            let mut args = std::env::args().collect::<Vec<String>>();
+            let mut args_str = args.iter().map(|s| s.as_str()).collect::<Vec<&str>>();
+            $crate::name::_named_flag($named, args_str.as_slice())
+        };
+    };
+}
+
+pub fn _named_flag(name: Name, args: &[&str]) -> bool {
+    args.iter()
+        .find(|s| {
+            if name.long.is_some() {
+                return **s == format!("--{}", name.long.clone().unwrap());
+            }
+
+            if name.short.is_some() {
+                return **s == format!("-{}", name.short.clone().unwrap());
+            }
+
+            false
+        })
+        .is_some()
 }

--- a/tests/boolean_flag.rs
+++ b/tests/boolean_flag.rs
@@ -41,7 +41,7 @@ fn should_enable_flag_of_long_and_short_named_arg() {
 
     named_flag!(
         both_named_boolean,
-        NameBuilder::new().long("both-named-arg").short("b").build(),
+        NameBuilder::of_long_and_short("both-named-arg", "b").build(),
         args
     );
 

--- a/tests/boolean_flag.rs
+++ b/tests/boolean_flag.rs
@@ -18,7 +18,7 @@ fn should_not_enable_flag_when_no_arg_given() {
 
 #[test]
 fn should_enable_named_flag_when_arg_given_with_long_and_short_name() {
-    let args = ["--long-named-arg", "-s"];
+    let mut args = ["--long-named-arg", "-s"];
 
     named_flag!(long_named_boolean, Name::long("long-named-arg"), args);
     named_flag!(short_named_boolean, Name::short("s"), args);
@@ -29,9 +29,16 @@ fn should_enable_named_flag_when_arg_given_with_long_and_short_name() {
 
 #[test]
 fn should_enable_flag_of_long_and_short_named_arg() {
-    let args = ["--both-named-arg", "-b"];
+    let mut args = ["--both-named-arg", "-b"];
 
     named_flag!(both_named_boolean, Name::new("both-named-arg", "b"), args);
 
     assert!(both_named_boolean);
+}
+
+#[test]
+fn should_not_enable_flag_of_long_and_short_named_arg_not_given() {
+    named_flag!(not_enabled, Name::new("both-named-arg", "b"));
+
+    assert!(!not_enabled);
 }

--- a/tests/boolean_flag.rs
+++ b/tests/boolean_flag.rs
@@ -1,4 +1,4 @@
-use ezcli::{flag, name::NameBuilder, named_flag};
+use ezcli::{flag, name::Name, named_flag};
 
 #[test]
 fn should_enable_boolean_flag_when_arg_given() {
@@ -20,16 +20,8 @@ fn should_not_enable_flag_when_no_arg_given() {
 fn should_enable_named_flag_when_arg_given_with_long_and_short_name() {
     let args = ["--long-named-arg", "-s"];
 
-    named_flag!(
-        long_named_boolean,
-        NameBuilder::new().long("long-named-arg").build(),
-        args
-    );
-    named_flag!(
-        short_named_boolean,
-        NameBuilder::new().short("s").build(),
-        args
-    );
+    named_flag!(long_named_boolean, Name::long("long-named-arg"), args);
+    named_flag!(short_named_boolean, Name::short("s"), args);
 
     assert!(long_named_boolean);
     assert!(short_named_boolean);
@@ -39,11 +31,7 @@ fn should_enable_named_flag_when_arg_given_with_long_and_short_name() {
 fn should_enable_flag_of_long_and_short_named_arg() {
     let args = ["--both-named-arg", "-b"];
 
-    named_flag!(
-        both_named_boolean,
-        NameBuilder::of_long_and_short("both-named-arg", "b").build(),
-        args
-    );
+    named_flag!(both_named_boolean, Name::new("both-named-arg", "b"), args);
 
     assert!(both_named_boolean);
 }

--- a/tests/boolean_flag.rs
+++ b/tests/boolean_flag.rs
@@ -1,4 +1,4 @@
-use ezcli::flag;
+use ezcli::{flag, name::NameBuilder, named_flag};
 
 #[test]
 fn should_enable_boolean_flag_when_arg_given() {
@@ -14,4 +14,36 @@ fn should_not_enable_flag_when_no_arg_given() {
     flag!(not_enabled);
 
     assert!(!not_enabled);
+}
+
+#[test]
+fn should_enable_named_flag_when_arg_given_with_long_and_short_name() {
+    let args = ["--long-named-arg", "-s"];
+
+    named_flag!(
+        long_named_boolean,
+        NameBuilder::new().long("long-named-arg").build(),
+        args
+    );
+    named_flag!(
+        short_named_boolean,
+        NameBuilder::new().short("s").build(),
+        args
+    );
+
+    assert!(long_named_boolean);
+    assert!(short_named_boolean);
+}
+
+#[test]
+fn should_enable_flag_of_long_and_short_named_arg() {
+    let args = ["--both-named-arg", "-b"];
+
+    named_flag!(
+        both_named_boolean,
+        NameBuilder::new().long("both-named-arg").short("b").build(),
+        args
+    );
+
+    assert!(both_named_boolean);
 }


### PR DESCRIPTION
Add named version of flag to allow for a more customizable CLI.
Previously the name was solely determined on the variable name (still viable), but that relies
on it being valid to Rust (syntax-wise and convention-wise).